### PR TITLE
Changes made to BuyOrder Manager and LocalShare

### DIFF
--- a/code/server-processes/src/classes/classes/local_share.py
+++ b/code/server-processes/src/classes/classes/local_share.py
@@ -1,3 +1,4 @@
+import numpy as np
 
 class LocalShare:
     def __init__(self, id: int, company_id: int, stake: float, purchased_price: float, company_share_id: int, purchasable: bool, user_id: int, sale_price: float,):
@@ -13,4 +14,4 @@ class LocalShare:
     def __eq__(self, other):
         if not isinstance(other, LocalShare):
             return NotImplemented
-        return self.id == other.id and self.company_id == other.company_id and self.stake == other.stake and self.purchased_price == other.purchased_price and self.purchasable == other.purchasable and self.user_id == other.user_id and self.sale_price == other.sale_price and self.company_share_id == other.company_share_id
+        return self.id == other.id and self.company_id == other.company_id and self.stake == other.stake and np.floor(self.purchased_price) == np.floor(other.purchased_price) and self.purchasable == other.purchasable and self.user_id == other.user_id and np.floor(self.sale_price) == np.floor(other.sale_price) and self.company_share_id == other.company_share_id

--- a/code/server-processes/src/classes/modules/buy_order_manager.py
+++ b/code/server-processes/src/classes/modules/buy_order_manager.py
@@ -91,7 +91,8 @@ class BuyOrderManager:
         
     
     def attempt_to_fulfill_order(self, order: BuyOrder) -> None:
-        shares_response = self.supabase.table("shares").select("*").neq('user_id', order.user_id).eq("share_id", order.company_share_id).lt("sale_price", order.order_maximum).eq("purchasable", True).order("sale_price", desc=False).limit(order.order_quantity).execute()
+        max_quantity = min(order.order_quantity, 5000)
+        shares_response = self.supabase.table("shares").select("*").neq('user_id', order.user_id).eq("share_id", order.company_share_id).lt("sale_price", order.order_maximum).eq("purchasable", True).order("sale_price", desc=False).limit(max_quantity).execute()
         share_data: list[dict] = shares_response.data if shares_response.data is not None else []
         
         available_share_ids = list(map(lambda x: x["id"], share_data))


### PR DESCRIPTION
Maximum number of shares the buy order can do in one go set to 5000 to avoid time outs, verifier function within localshare modified to make floating point rounding not a determining factor as to why a share does not equal another share