### PR TITLE
BuyOrder Pricing Fix 

### DIFF
--- a/code/server-processes/src/classes/modules/sqlite_assistant.py
+++ b/code/server-processes/src/classes/modules/sqlite_assistant.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from supabase import Client
 
+from classes.classes.buy_order import BuyOrder
 from classes.classes.local_share import LocalShare
 from rich.progress import Progress
 
@@ -48,6 +49,18 @@ class SqliteAssistant:
             """)
             
             cursor.execute("""
+            CREATE TABLE IF NOT EXISTS buy_orders (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                expires_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                company_share_id INTEGER,
+                user_id INTEGER,
+                maximum_share_price REAL NOT NULL DEFAULT 0,
+                order_quantity INTEGER
+            ) STRICT;
+            """)
+            
+            cursor.execute("""
             CREATE INDEX IF NOT EXISTS idx_shares_share_id
             ON shares(share_id);
             """)
@@ -56,6 +69,17 @@ class SqliteAssistant:
             CREATE INDEX IF NOT EXISTS idx_shares_user_id
             ON shares(user_id);
             """)
+            
+            cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_buy_orders_company_share_id
+            ON buy_orders(company_share_id);
+            """)
+            
+            cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_buy_orders_user_id
+            ON buy_orders(user_id);
+            """)
+            
             cursor.close()
     
     def __enter__(self):
@@ -315,11 +339,6 @@ class SqliteAssistant:
         except sqlite3.Error as e:
             print("Transaction Failed for updating local shares owners --> Rolling back")
             return False
-   
-            
-        
-                
-
     
     def update_local_shares_purchased_price_post_transaction(self, share_ids: list[int],) -> bool:
         
@@ -346,10 +365,110 @@ class SqliteAssistant:
             return False
 
 
+    #
+    # I do not plan on using this infrastructure for buyorders but in the future I might so ill leave it here
+    #
+    def insert_buy_order(self, buy_order: BuyOrder) -> bool:
         
+        with self.conn:
         
+            cursor = self.conn.cursor()
+            
+            cursor.execute(
+                """
+                INSERT INTO buy_orders (
+                    id, created_at, expires_at, company_share_id, user_id, maximum_share_price, order_quantity
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (buy_order.id, buy_order.created_at, buy_order.expires_at, buy_order.company_share_id, buy_order.user_id, buy_order.order_maximum, buy_order.order_quantity)
+            )
+            cursor.close()
+           
+        return True
+    
+    #
+    # I do not plan on using this infrastructure for buyorders but in the future I might so ill leave it here
+    #
+    def delete_buy_order_by_order_id(self, order_id: int) -> bool:
         
-
+        with self.conn:
+            
+            cursor = self.conn.cursor()
+            
+            cur = cursor.execute(
+                """
+                DELETE FROM buy_orders
+                WHERE id = ?
+                """,
+                (order_id,)
+            )
+            
+            cursor.close()
+        
+        return cur.rowcount > 0
+    
+    #
+    # I do not plan on using this infrastructure for buyorders but in the future I might so ill leave it here
+    #
+    def get_all_buy_orders(self) -> list[BuyOrder]:
+        
+        cursor = self.conn.cursor()
+        
+        cursor.execute("SELECT * FROM buy_orders")
+        
+        buy_order_results = cursor.fetchall()
+        
+        cursor.close()
+        
+        buy_order_list = []
+        
+        for buy_order_raw in buy_order_results:
+        
+            buy_order = BuyOrder(
+                id = buy_order_raw ["id"],
+                created_at = buy_order_raw ["created_at"],
+                expires_at = buy_order_raw ["expires_at"],
+                company_share_id = buy_order_raw ["company_share_id"],
+                user_id = buy_order_raw ["user_id"],
+                order_maximum = buy_order_raw ["maximum_share_price"],
+                order_quantity = buy_order_raw ["order_quantity"]
+            )
+            
+            buy_order_list.append(buy_order)
+        
+        return buy_order_list
+    
+    #
+    # I do not plan on using this infrastructure for buyorders but in the future I might so ill leave it here
+    #    
+    def get_buy_orders_by_user_id(self, user_id: int) -> list[BuyOrder]:
+        
+        cursor = self.conn.cursor()
+        
+        cursor.execute("SELECT * FROM buy_orders WHERE user_id = ?", (user_id,))
+        
+        buy_order_results = cursor.fetchall()
+        
+        cursor.close()
+        
+        buy_order_list = []
+        
+        for buy_order_raw in buy_order_results:
+        
+            buy_order = BuyOrder(
+                id = buy_order_raw ["id"],
+                created_at = buy_order_raw ["created_at"],
+                expires_at = buy_order_raw ["expires_at"],
+                company_share_id = buy_order_raw ["company_share_id"],
+                user_id = buy_order_raw ["user_id"],
+                order_maximum = buy_order_raw ["maximum_share_price"],
+                order_quantity = buy_order_raw ["order_quantity"]
+            )
+            
+            buy_order_list.append(buy_order)
+        
+        return buy_order_list
 
     
     def insert_local_share(self, id: int, created_at: str, company_id : int, stake: float, purchased_price: float, purchasable: bool, user_id: int, sale_price: float, share_id: int):
@@ -422,6 +541,6 @@ class SqliteAssistant:
 
         print("All Shares Replicated")
             
-
+    
     
         

--- a/code/server-processes/src/classes/modules/stocks_ai.py
+++ b/code/server-processes/src/classes/modules/stocks_ai.py
@@ -478,9 +478,9 @@ class StocksAI:
         if max_amount_to_invest_into_one_stock < max_amount_to_invest_currently:
             max_amount_to_invest_currently = max_amount_to_invest_into_one_stock
         
-        quanitity_of_shares_to_buy = int(max_amount_to_invest_currently // (share_to_buy.value * 1.1) )
+        quantity_of_shares_to_buy = int(max_amount_to_invest_currently // (share_to_buy.value * 1.1) )
         
-        if quanitity_of_shares_to_buy <= 0:
+        if quantity_of_shares_to_buy <= 0:
             print(f"[yellow][{datetime.datetime.now().replace(second=0, microsecond=0)}] {user.minecraft_username} is returning without a buy order because they cannot afford to purchase a share for {self.company_map[share_to_buy.company_id].name}[/yellow]")
             return
         
@@ -492,29 +492,32 @@ class StocksAI:
             print(f"[yellow][{datetime.datetime.now().replace(second=0, microsecond=0)}] {user.minecraft_username} is returning without a buy order because they already have a buy order for {self.company_map[share_to_buy.company_id].name}[/yellow]")
             return 
         
-        buy_order_price = self.decide_buy_order_max_price(share_to_buy, current_buy_orders)
+        buy_order_price = self.decide_buy_order_max_price(share_to_buy, current_buy_orders, quantity_of_shares_to_buy)
         
         time_plus_one = datetime.datetime.now() + datetime.timedelta(hours=1)
         
-        buy_order = BuyOrder(id = 0, created_at = "", expires_at = time_plus_one.isoformat(), company_share_id = share_to_buy.id, user_id = user.id, order_maximum = buy_order_price, order_quantity = quanitity_of_shares_to_buy)
+        buy_order = BuyOrder(id = 0, created_at = "", expires_at = time_plus_one.isoformat(), company_share_id = share_to_buy.id, user_id = user.id, order_maximum = buy_order_price, order_quantity = quantity_of_shares_to_buy)
         
-        user.place_buy_order(buy_order=buy_order)
+        # Update local cache since many users will use it right after placing this order
+        self.trade_helper.update_buy_orders_for_share(buy_order = buy_order)
+        
+        user.place_buy_order(buy_order = buy_order)
         
         print(f"[bright_green][{datetime.datetime.now().replace(second=0, microsecond=0)}] {user.minecraft_username} placed a buy order for {self.company_map[share_to_buy.company_id].name} at ${buy_order.order_maximum} with {buy_order.order_quantity} quantity[/bright_green]")
         
         
         
-    def decide_buy_order_max_price(self, share: CompanyShare, current_buy_orders: list[BuyOrder]) -> float:
+    def decide_buy_order_max_price(self, share: CompanyShare, current_buy_orders: list[BuyOrder], quantity_of_shares_to_buy: int) -> float:
         
         if current_buy_orders:
         
-            most_expensive_order = current_buy_orders[FIRST].order_maximum
+            most_expensive_order = max(current_buy_orders, key = lambda buy_order: buy_order.order_maximum)
             
-            if most_expensive_order / share.value > 1.1:
+            if most_expensive_order.order_maximum / share.value > 1.1:
                 return share.value * 1.1
             
             else:
-                return most_expensive_order * 1.01
+                return most_expensive_order.order_maximum  * 1.01
         
         else:
             return share.value 

--- a/code/server-processes/src/classes/modules/trade_helper.py
+++ b/code/server-processes/src/classes/modules/trade_helper.py
@@ -21,7 +21,7 @@ class TradeHelper:
         
     
     
-    def get_buy_orders_for_share(self, company_share_id: int, desc = True) -> List[BuyOrder]:
+    def get_buy_orders_for_share(self, company_share_id: int) -> List[BuyOrder]:
         
         buy_orders = self.local_cache_manager.get(f"buy_order:by_company_share:{company_share_id}")
         
@@ -50,8 +50,6 @@ class TradeHelper:
                 )
                 for x in buy_orders_raw
             ]
-            
-            buy_orders.sort(key=lambda o: o.order_maximum, reverse=desc)
             
             self.local_cache_manager.set(f"buy_order:by_company_share:{company_share_id}", buy_orders)
             
@@ -97,6 +95,20 @@ class TradeHelper:
         lowest_price_share = min(shares, key=lambda x: x['sale_price'])
         self.local_cache_manager.set(f"price:for_cheapest_share_by_company_id:{share.company.id}", float(lowest_price_share['sale_price']), ttl=60)
         return lowest_price_share['sale_price']
+    
+    def update_buy_orders_for_share(self, buy_order: BuyOrder):
+        
+        buy_orders : Optional[list[BuyOrder]] = self.local_cache_manager.get(f"buy_order:by_company_share:{buy_order.company_share_id}")
+        
+        # If there is a cache miss return early
+        if type(buy_orders) is not list:
+            print(f"[yellow][UPDATE_BUY_ORDERS_FOR_SHARE]Cache Missed for company_share_id: {buy_order.company_share_id}[/yellow]")
+            return
+        
+        buy_orders.append(buy_order)
+            
+        self.local_cache_manager.set(f"buy_order:by_company_share:{buy_order.company_share_id}", buy_orders)
+            
 
     def is_valid_buy_orders(self, share: Share, buy_orders: list[BuyOrder], last_sale_price_margin: float) -> bool:
             
@@ -122,8 +134,6 @@ class TradeHelper:
         
         buy_orders = self.get_buy_orders_for_share(company_share_id = share_group.head_share.company_share.id)
         
-        #TODO 
-        #Migrate to place_share_group_sell_order
         if self.is_valid_buy_orders(share = share_group.head_share, buy_orders=buy_orders, last_sale_price_margin=0.9):
             
             highest_value_buy_order = buy_orders[FIRST]


### PR DESCRIPTION
Fixes Issue with buy orders max_price not being able to exceed the current price of the share due to the cashed value remaining constant through all bots turns even when the data can be updated in the cache locally without using Egress