### PR TITLE
Fix quantity input replacing text instead of appending

### DIFF
--- a/code/client/economycraft/lib/common_widgets/product_market_tile_widget.dart
+++ b/code/client/economycraft/lib/common_widgets/product_market_tile_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:economycraft/classes/product.dart';
+import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -198,15 +199,33 @@ class _ProductTileWidgetState extends State<ProductMarketTileWidget> {
           builder: (context, setState) {
             // Update total when quantity changes
             void updateTotal(String value) {
-              setState(() {
-                quantity = int.tryParse(value) ?? 1;
-                if (quantity < 1) quantity = 1;
-                if (quantity > widget.product.quantity) {
-                  quantity = widget.product.quantity;
+              // Parse the input value
+              final parsedQuantity = int.tryParse(value);
+
+              // Only proceed if input is a valid number
+              if (parsedQuantity == null) {
+                return;
+              }
+
+              // Validate and clamp the quantity within acceptable bounds
+              int newQuantity = parsedQuantity;
+              if (newQuantity < 1) newQuantity = 1;
+              if (newQuantity > widget.product.quantity) {
+                newQuantity = widget.product.quantity;
+              }
+
+              // Only update state if the quantity actually changed
+              if (newQuantity != quantity) {
+                setState(() {
+                  quantity = newQuantity;
+                  totalPrice = widget.product.price * quantity;
+                });
+
+                // Update controller text only if validation changed the value
+                if (newQuantity != parsedQuantity) {
+                  _quantityController.text = newQuantity.toString();
                 }
-                _quantityController.text = quantity.toString();
-                totalPrice = widget.product.price * quantity;
-              });
+              }
             }
 
             return Dialog(
@@ -370,6 +389,9 @@ class _ProductTileWidgetState extends State<ProductMarketTileWidget> {
                               controller: _quantityController,
                               keyboardType: TextInputType.number,
                               textAlign: TextAlign.center,
+                              inputFormatters: [
+                                FilteringTextInputFormatter.digitsOnly,
+                              ],
                               onChanged: updateTotal,
                               decoration: const InputDecoration(
                                 border: OutlineInputBorder(),


### PR DESCRIPTION
## Problem
When typing in the product quantity field, the first digit would append normally, but typing the second digit would replace the first one instead of appending. This made selecting quantities a frustrating experience.

The issue was caused by the `updateTotal()` method unconditionally reassigning the text controller on every keystroke, which was resetting the text field's selection state.

## Solution
Changed the logic to:
- Only parse valid numeric input (ignoring invalid characters early)
- Only call `setState()` when quantity actually changes after validation
- Only update the controller text if validation actually modified the value (like clamping to min/max)
- Leave user input alone if it's already valid

This prevents the feedback loop and keeps the text cursor in the right place while typing.

## Testing
Tested manually:
- Typing single digit ✓
- Typing multiple digits ✓
- Exceeding max stock (auto-clamps) ✓
- Using +/- buttons ✓
- Clearing and retyping ✓